### PR TITLE
Implement reading qvd files from Python IO

### DIFF
--- a/qvd/qvd_reader.py
+++ b/qvd/qvd_reader.py
@@ -1,13 +1,29 @@
-from .qvd import read_qvd
+from .qvd import read_qvd, read_qvd_from_buffer
 import pandas as pd
+import io
 
 
-def read(file_name):
-    data = read_qvd(file_name)
-    df = pd.DataFrame.from_dict(data)
+def read(file):
+    data_dict = read_to_dict(file)
+    df = pd.DataFrame.from_dict(data_dict)
     return df
 
 
-def read_to_dict(file_name):
-    data = read_qvd(file_name)
-    return data
+def read_to_dict(file):
+    if (isinstance(file, io.TextIOBase)
+        or isinstance(file, io.BufferedIOBase)
+        or isinstance(file, io.RawIOBase)
+        or isinstance(file, io.IOBase)):
+        try:
+            unpacked_data = file.read()
+        except UnicodeDecodeError as e:
+            raise Exception("Supply a raw file access. Use mode \"rb\" instead of mode \"r\"")
+    elif isinstance(file, bytes):
+        unpacked_data = file
+    elif isinstance(file, str):
+        return read_qvd(file)
+    else:
+        raise Exception("Please supply a raw string or a file")
+    result_data = read_qvd_from_buffer(unpacked_data)
+    return result_data
+

--- a/qvd/test_qvd_reader.py
+++ b/qvd/test_qvd_reader.py
@@ -14,3 +14,11 @@ class TestQvdReader():
         qvd = qvd_reader.read(f'{os.path.dirname(__file__)}/test_files/AAPL.qvd')
         csv = pd.read_csv(f'{os.path.dirname(__file__)}/test_files/AAPL.csv', float_precision='round_trip')
         assert np.array_equal(np.sort(qvd.columns, axis=0), np.sort(csv.columns, axis=0))
+
+    def test_qvd_from_in_memory(self):
+        with open(f'{os.path.dirname(__file__)}/test_files/AAPL.qvd', 'rb') as fin:
+            qvd = qvd_reader.read(fin)
+        csv = pd.read_csv(f'{os.path.dirname(__file__)}/test_files/AAPL.csv', float_precision='round_trip')
+        assert qvd.shape == csv.shape
+        assert np.array_equal(np.sort(qvd.columns, axis=0), np.sort(csv.columns, axis=0))
+


### PR DESCRIPTION
Hi,
I'm a big fan of this library. It has really helped me to work with QVD files. Thank you so much.

Currently this library only works when reading in qvd files via a file name, but I have a use case, where the data I want to read in is not available in to my Python interpreter in that format. I would like to read in qvd files from either in-memory bytes from Python or from Python File objects:
- io.TextIOBase
- io.BufferedIOBase
- io.RawIOBase
- io.IOBase

As a starting point I implemented this myself.
Now, with these changes, qvd files can be read in the current way:
```py
from qvd import qvd_reader
qvd_reader.read("qvd/test_files/AAPL.qvd")
```

But also via
```py
with open("qvd/test_files/AAPL.qvd", "rb") as fin:
    qvd_reader.read(fin)
```

I also added an error message for a common mistake one could make:
```py
>>> with open("qvd/test_files/AAPL.qvd", "r") as fin:
...     qvd_reader.read(fin)
...
Traceback (most recent call last):
  File ".../qvd-utils/qvd/qvd_reader.py", line 18, in read_to_dict
    unpacked_data = file.read()
                    ^^^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 5816: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/.../qvd-utils/qvd/qvd_reader.py", line 7, in read
    data_dict = read_to_dict(file)
                ^^^^^^^^^^^^^^^^^^
  File "/.../qvd-utils/qvd/qvd_reader.py", line 20, in read_to_dict
    raise Exception("Supply a raw file access. Use mode \"rb\" instead of mode \"r\"")
Exception: Supply a raw file access. Use mode "rb" instead of mode "r"
```

There is room for improvement here, as there is code duplication between the function `read_qvd` and `read_qvd_from_buffer`. I tried to unify it, but the BufRead of the Cursor over the `Vec<u8>` and the BufRead on the file behaved differently, so I let it like it is.

Maybe someone else finds a way to make it better?